### PR TITLE
Ensure mod_headers is enabled by default

### DIFF
--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -12,6 +12,6 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install soap
 
-RUN a2enmod rewrite
+RUN a2enmod rewrite headers
 
 COPY magento.conf /etc/apache2/conf-enabled/


### PR DESCRIPTION
Should require a2enmod headers in the Dockerfile.
