### PR TITLE
Add PHP-7.0

### DIFF
--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:7.0-apache
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-dev libxml2-dev" \
+    && apt-get update && apt-get install -y $build_packages \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd \
+    && docker-php-ext-install mbstring \
+    && docker-php-ext-install mcrypt \
+    && docker-php-ext-install pcntl \
+    && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-install soap
+
+RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
+
+RUN a2enmod rewrite headers
+
+COPY magento.conf /etc/apache2/conf-enabled/
+
+COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/7.0/apache/magento.conf
+++ b/7.0/apache/magento.conf
@@ -1,0 +1,2 @@
+# Enable support for SSL termination
+SetEnvIf X-Forwarded-Proto https HTTPS=on

--- a/7.0/apache/php.ini
+++ b/7.0/apache/php.ini
@@ -1,0 +1,6 @@
+; Set the default time zone to silence warnings
+date.timezone=UTC
+
+; Xdebug settings
+xdebug.remote_enable=1
+xdebug.remote_autostart=0

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.0-cli
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-dev libxml2-dev" \
+    && apt-get update && apt-get install -y $build_packages \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install gd \
+    && docker-php-ext-install mbstring \
+    && docker-php-ext-install mcrypt \
+    && docker-php-ext-install pcntl \
+    && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-install soap
+
+RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug

--- a/7.0/cli/php.ini
+++ b/7.0/cli/php.ini
@@ -1,0 +1,6 @@
+; Set the default time zone to silence warnings
+date.timezone=UTC
+
+; Xdebug settings
+xdebug.remote_enable=1
+xdebug.remote_autostart=0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A collection of Docker images for running Magento application web servers and co
 
 # Supported tags and respective `Dockerfile` links
 
+- [`7.0-apache` (*7.0/apache/Dockerfile*)](https://github.com/meanbee/docker-magento/blob/master/7.0/apache/Dockerfile)
+- [`7.0-cli` (*7.0/cli/Dockerfile*)](https://github.com/meanbee/docker-magento/blob/master/7.0/cli/Dockerfile)
 - [`5.6-apache` (*5.6/apache/Dockerfile*)](https://github.com/meanbee/docker-magento/blob/master/5.6/apache/Dockerfile)
 - [`5.6-cli` (*5.6/cli/Dockerfile*)](https://github.com/meanbee/docker-magento/blob/master/5.6/cli/Dockerfile)
 - [`5.5-apache` (*5.5/apache/Dockerfile*)](https://github.com/meanbee/docker-magento/blob/master/5.5/apache/Dockerfile)


### PR DESCRIPTION
This checks off PHP 7 from Issue #10.

I've had to add a beta version of xdebug because there isn't a stable release yet for PHP 7.0 support. When there is we can update.
