### PR TITLE
Set a memory limit of 512mb for all images

### DIFF
--- a/5.5/apache/php.ini
+++ b/5.5/apache/php.ini
@@ -4,3 +4,6 @@ date.timezone=UTC
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
+
+; Previous Magento recommended memory setting
+memory_limit=512M

--- a/5.5/cli/php.ini
+++ b/5.5/cli/php.ini
@@ -4,3 +4,6 @@ date.timezone=UTC
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
+
+; Previous Magento recommended memory setting
+memory_limit=512M

--- a/5.6/apache/php.ini
+++ b/5.6/apache/php.ini
@@ -4,3 +4,6 @@ date.timezone=UTC
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
+
+; Previous Magento recommended memory setting
+memory_limit=512M

--- a/5.6/cli/php.ini
+++ b/5.6/cli/php.ini
@@ -4,3 +4,6 @@ date.timezone=UTC
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
+
+; Previous Magento recommended memory setting
+memory_limit=512M

--- a/7.0/apache/php.ini
+++ b/7.0/apache/php.ini
@@ -4,3 +4,6 @@ date.timezone=UTC
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
+
+; Previous Magento recommended memory setting
+memory_limit=512M

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -13,3 +13,5 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
     && docker-php-ext-install soap
 
 RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
+
+COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/7.0/cli/php.ini
+++ b/7.0/cli/php.ini
@@ -4,3 +4,6 @@ date.timezone=UTC
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
+
+; Magento recommended memory setting
+memory_limit=512M


### PR DESCRIPTION
Updates the memory limit to the old recommendation from Magento of 512mb.  I added in the php.ini for the version 7.0 build of the cli container.

Closes #8.
