### PR TITLE
Build Dockerfiles up from templates powered by m4

### DIFF
--- a/5.5/apache/Dockerfile.m4
+++ b/5.5/apache/Dockerfile.m4
@@ -1,0 +1,8 @@
+FROM php:5.5-apache
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+include(`dockerfile/extensions.m4')
+include(`dockerfile/xdebug.m4')
+include(`dockerfile/php-ini.m4')
+include(`dockerfile/apache.m4')

--- a/5.5/apache/magento.conf.m4
+++ b/5.5/apache/magento.conf.m4
@@ -1,0 +1,1 @@
+include(`apache/conf.m4')

--- a/5.5/apache/php.ini.m4
+++ b/5.5/apache/php.ini.m4
@@ -1,0 +1,2 @@
+include(`php-ini/general.m4')
+include(`php-ini/xdebug.m4')

--- a/5.5/cli/Dockerfile
+++ b/5.5/cli/Dockerfile
@@ -15,3 +15,4 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
+

--- a/5.5/cli/Dockerfile.m4
+++ b/5.5/cli/Dockerfile.m4
@@ -1,0 +1,7 @@
+FROM php:5.5-cli
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+include(`dockerfile/extensions.m4')
+include(`dockerfile/xdebug.m4')
+include(`dockerfile/php-ini.m4')

--- a/5.5/cli/php.ini
+++ b/5.5/cli/php.ini
@@ -1,9 +1,10 @@
 ; Set the default time zone to silence warnings
 date.timezone=UTC
 
+; Magento recommended memory setting
+memory_limit=512M
+
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
 
-; Previous Magento recommended memory setting
-memory_limit=512M

--- a/5.5/cli/php.ini.m4
+++ b/5.5/cli/php.ini.m4
@@ -1,0 +1,2 @@
+include(`php-ini/general.m4')
+include(`php-ini/xdebug.m4')

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -14,8 +14,9 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
 
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
+COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
+
 RUN a2enmod rewrite headers
 
 COPY magento.conf /etc/apache2/conf-enabled/
 
-COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/5.6/apache/Dockerfile.m4
+++ b/5.6/apache/Dockerfile.m4
@@ -1,0 +1,8 @@
+FROM php:5.6-apache
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+include(`dockerfile/extensions.m4')
+include(`dockerfile/xdebug.m4')
+include(`dockerfile/php-ini.m4')
+include(`dockerfile/apache.m4')

--- a/5.6/apache/magento.conf
+++ b/5.6/apache/magento.conf
@@ -1,2 +1,3 @@
 # Enable support for SSL termination
 SetEnvIf X-Forwarded-Proto https HTTPS=on
+

--- a/5.6/apache/magento.conf.m4
+++ b/5.6/apache/magento.conf.m4
@@ -1,0 +1,1 @@
+include(`apache/conf.m4')

--- a/5.6/apache/php.ini
+++ b/5.6/apache/php.ini
@@ -1,9 +1,10 @@
 ; Set the default time zone to silence warnings
 date.timezone=UTC
 
+; Magento recommended memory setting
+memory_limit=512M
+
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
 
-; Previous Magento recommended memory setting
-memory_limit=512M

--- a/5.6/apache/php.ini.m4
+++ b/5.6/apache/php.ini.m4
@@ -1,0 +1,2 @@
+include(`php-ini/general.m4')
+include(`php-ini/xdebug.m4')

--- a/5.6/cli/Dockerfile
+++ b/5.6/cli/Dockerfile
@@ -15,3 +15,4 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
+

--- a/5.6/cli/Dockerfile.m4
+++ b/5.6/cli/Dockerfile.m4
@@ -1,0 +1,7 @@
+FROM php:5.6-cli
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+include(`dockerfile/extensions.m4')
+include(`dockerfile/xdebug.m4')
+include(`dockerfile/php-ini.m4')

--- a/5.6/cli/php.ini
+++ b/5.6/cli/php.ini
@@ -1,9 +1,10 @@
 ; Set the default time zone to silence warnings
 date.timezone=UTC
 
+; Magento recommended memory setting
+memory_limit=512M
+
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
 
-; Previous Magento recommended memory setting
-memory_limit=512M

--- a/5.6/cli/php.ini.m4
+++ b/5.6/cli/php.ini.m4
@@ -1,0 +1,2 @@
+include(`php-ini/general.m4')
+include(`php-ini/xdebug.m4')

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -12,10 +12,11 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install soap
 
-RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
+RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
+
+COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 RUN a2enmod rewrite headers
 
 COPY magento.conf /etc/apache2/conf-enabled/
 
-COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/7.0/apache/Dockerfile.m4
+++ b/7.0/apache/Dockerfile.m4
@@ -1,0 +1,8 @@
+FROM php:7.0-apache
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+include(`dockerfile/extensions.m4')
+include(`dockerfile/xdebug.m4')
+include(`dockerfile/php-ini.m4')
+include(`dockerfile/apache.m4')

--- a/7.0/apache/magento.conf
+++ b/7.0/apache/magento.conf
@@ -1,2 +1,3 @@
 # Enable support for SSL termination
 SetEnvIf X-Forwarded-Proto https HTTPS=on
+

--- a/7.0/apache/magento.conf.m4
+++ b/7.0/apache/magento.conf.m4
@@ -1,0 +1,1 @@
+include(`apache/conf.m4')

--- a/7.0/apache/php.ini
+++ b/7.0/apache/php.ini
@@ -1,9 +1,10 @@
 ; Set the default time zone to silence warnings
 date.timezone=UTC
 
+; Magento recommended memory setting
+memory_limit=512M
+
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
 
-; Previous Magento recommended memory setting
-memory_limit=512M

--- a/7.0/apache/php.ini.m4
+++ b/7.0/apache/php.ini.m4
@@ -1,0 +1,2 @@
+include(`php-ini/general.m4')
+include(`php-ini/xdebug.m4')

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -12,6 +12,7 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install soap
 
-RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
+RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
+

--- a/7.0/cli/Dockerfile.m4
+++ b/7.0/cli/Dockerfile.m4
@@ -1,0 +1,7 @@
+FROM php:7.0-cli
+
+MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
+
+include(`dockerfile/extensions.m4')
+include(`dockerfile/xdebug.m4')
+include(`dockerfile/php-ini.m4')

--- a/7.0/cli/php.ini
+++ b/7.0/cli/php.ini
@@ -1,9 +1,10 @@
 ; Set the default time zone to silence warnings
 date.timezone=UTC
 
+; Magento recommended memory setting
+memory_limit=512M
+
 ; Xdebug settings
 xdebug.remote_enable=1
 xdebug.remote_autostart=0
 
-; Magento recommended memory setting
-memory_limit=512M

--- a/7.0/cli/php.ini.m4
+++ b/7.0/cli/php.ini.m4
@@ -1,0 +1,2 @@
+include(`php-ini/general.m4')
+include(`php-ini/xdebug.m4')

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A sample `docker-compose.yml` configuration:
         - 443
       links:
         - db
-    
+
     db:
       image: mysql/mysql-server:5.6
       environment:
@@ -46,3 +46,15 @@ Xdebug is installed and enabled on all the images by default. To configure it fo
 the container with the following environment variable set (replacing the `{}` placeholders with appropriate values):
 
     XDEBUG_CONFIG="remote_host={IP_ADDRESS} idekey={IDEKEY}"
+
+# Building
+
+A lot of the configuration for each image is the same, with the difference being the base image that they're extending from.  For this reason `m4` is used as a templating engine to include partials stored in `lib/` into the `Dockerfile`.  The `Dockerfile` should still be published to the repository due to Docker Hub needing a `Dockerfile` to build from.
+
+To build all `Dockerfile`s use make:
+
+    make
+
+To build a specific `Dockerfile`, use make with the path to the `Dockerfile`, e.g.:
+
+    make 7.0/apache/Dockerfile

--- a/lib/apache/conf.m4
+++ b/lib/apache/conf.m4
@@ -1,3 +1,2 @@
 # Enable support for SSL termination
 SetEnvIf X-Forwarded-Proto https HTTPS=on
-

--- a/lib/dockerfile/apache.m4
+++ b/lib/dockerfile/apache.m4
@@ -1,0 +1,3 @@
+RUN a2enmod rewrite headers
+
+COPY magento.conf /etc/apache2/conf-enabled/

--- a/lib/dockerfile/extensions.m4
+++ b/lib/dockerfile/extensions.m4
@@ -1,7 +1,3 @@
-FROM php:5.5-apache
-
-MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
-
 RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-dev libxml2-dev" \
     && apt-get update && apt-get install -y $build_packages \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
@@ -11,12 +7,3 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
     && docker-php-ext-install pcntl \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install soap
-
-RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
-
-COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
-
-RUN a2enmod rewrite headers
-
-COPY magento.conf /etc/apache2/conf-enabled/
-

--- a/lib/dockerfile/php-ini.m4
+++ b/lib/dockerfile/php-ini.m4
@@ -1,0 +1,1 @@
+COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/lib/dockerfile/xdebug.m4
+++ b/lib/dockerfile/xdebug.m4
@@ -1,0 +1,1 @@
+RUN yes | pecl install xdebug && docker-php-ext-enable xdebug

--- a/lib/php-ini/general.m4
+++ b/lib/php-ini/general.m4
@@ -3,8 +3,3 @@ date.timezone=UTC
 
 ; Magento recommended memory setting
 memory_limit=512M
-
-; Xdebug settings
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-

--- a/lib/php-ini/xdebug.m4
+++ b/lib/php-ini/xdebug.m4
@@ -1,0 +1,3 @@
+; Xdebug settings
+xdebug.remote_enable=1
+xdebug.remote_autostart=0

--- a/makefile
+++ b/makefile
@@ -1,0 +1,24 @@
+TEMPLATE_LIB=lib/**/*.m4
+
+all: */*/Dockerfile
+
+%: %.m4 $(TEMPLATE_LIB)
+	m4 -I ./lib $@.m4 > $@
+
+5.5/cli/Dockerfile: 5.5/cli/Dockerfile.m4 5.5/cli/php.ini $(TEMPLATE_LIB)
+	m4 -I ./lib $@.m4 > $@
+
+5.5/apache/Dockerfile: 5.5/apache/Dockerfile.m4 5.5/apache/php.ini 5.5/apache/magento.conf $(TEMPLATE_LIB)
+	m4 -I ./lib $@.m4 > $@
+
+5.6/cli/Dockerfile: 5.6/cli/Dockerfile.m4 5.6/cli/php.ini $(TEMPLATE_LIB)
+	m4 -I ./lib $@.m4 > $@
+
+5.6/apache/Dockerfile: 5.6/apache/Dockerfile.m4 5.6/apache/php.ini 5.6/apache/magento.conf $(TEMPLATE_LIB)
+	m4 -I ./lib $@.m4 > $@
+
+7.0/cli/Dockerfile: 7.0/cli/Dockerfile.m4 7.0/cli/php.ini $(TEMPLATE_LIB)
+	m4 -I ./lib $@.m4 > $@
+
+7.0/apache/Dockerfile: 7.0/apache/Dockerfile.m4 7.0/apache/php.ini 7.0/apache/magento.conf $(TEMPLATE_LIB)
+	m4 -I ./lib $@.m4 > $@


### PR DESCRIPTION
I was getting frustrated by the fragility and effort of having to edit six Dockerfiles to make a global change, such as changing a php.ini setting.  I hope this PR goes some way to fixing that, so we can centralise standard configuration in a `lib/` folder and build up the Dockerfiles by using them as partials.

We may even be able to go further with this in the future and have a standard Dockerfile template and use variables to inject the FROM version number, but I think it's a step in the right direction.

Also, `make`!
