### PR TITLE
Setup Xdebug in entrypoint

### DIFF
--- a/5.5/fpm/entrypoint
+++ b/5.5/fpm/entrypoint
@@ -11,6 +11,14 @@ fi
 # Start sendmail
 /etc/init.d/sendmail start
 
+# Configure Xdebug
+if [ "$XDEBUG_CONFIG" ]; then
+    echo "" > /usr/local/etc/php/conf.d/zz-xdebug.ini
+    for config in $XDEBUG_CONFIG; do
+        echo "xdebug.$config" >> /usr/local/etc/php/conf.d/zz-xdebug.ini
+    done
+fi
+
 # Execute the supplied command
 exec "$@"
 

--- a/5.5/fpm/entrypoint.m4
+++ b/5.5/fpm/entrypoint.m4
@@ -1,4 +1,5 @@
 include(`entrypoint/header.m4')
 include(`entrypoint/cron.m4')
 include(`entrypoint/sendmail.m4')
+include(`entrypoint/xdebug.m4')
 include(`entrypoint/passthrough.m4')

--- a/5.5/fpm/php.ini
+++ b/5.5/fpm/php.ini
@@ -7,7 +7,3 @@ memory_limit=512M
 ; Sendmail
 sendmail_path=/usr/sbin/sendmail -t -i
 
-; Xdebug settings
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-

--- a/5.5/fpm/php.ini.m4
+++ b/5.5/fpm/php.ini.m4
@@ -1,3 +1,2 @@
 include(`php-ini/general.m4')
 include(`php-ini/mail.m4')
-include(`php-ini/xdebug.m4')

--- a/5.6/fpm/entrypoint
+++ b/5.6/fpm/entrypoint
@@ -11,6 +11,14 @@ fi
 # Start sendmail
 /etc/init.d/sendmail start
 
+# Configure Xdebug
+if [ "$XDEBUG_CONFIG" ]; then
+    echo "" > /usr/local/etc/php/conf.d/zz-xdebug.ini
+    for config in $XDEBUG_CONFIG; do
+        echo "xdebug.$config" >> /usr/local/etc/php/conf.d/zz-xdebug.ini
+    done
+fi
+
 # Execute the supplied command
 exec "$@"
 

--- a/5.6/fpm/entrypoint.m4
+++ b/5.6/fpm/entrypoint.m4
@@ -1,4 +1,5 @@
 include(`entrypoint/header.m4')
 include(`entrypoint/cron.m4')
 include(`entrypoint/sendmail.m4')
+include(`entrypoint/xdebug.m4')
 include(`entrypoint/passthrough.m4')

--- a/5.6/fpm/php.ini
+++ b/5.6/fpm/php.ini
@@ -7,7 +7,3 @@ memory_limit=512M
 ; Sendmail
 sendmail_path=/usr/sbin/sendmail -t -i
 
-; Xdebug settings
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-

--- a/5.6/fpm/php.ini.m4
+++ b/5.6/fpm/php.ini.m4
@@ -1,3 +1,2 @@
 include(`php-ini/general.m4')
 include(`php-ini/mail.m4')
-include(`php-ini/xdebug.m4')

--- a/lib/entrypoint/xdebug.m4
+++ b/lib/entrypoint/xdebug.m4
@@ -1,0 +1,7 @@
+# Configure Xdebug
+if [ "$XDEBUG_CONFIG" ]; then
+    echo "" > /usr/local/etc/php/conf.d/zz-xdebug.ini
+    for config in $XDEBUG_CONFIG; do
+        echo "xdebug.$config" >> /usr/local/etc/php/conf.d/zz-xdebug.ini
+    done
+fi


### PR DESCRIPTION
XDEBUG_CONFIG environment variable is not being used by php in the web
server, so the configuration has to be written to .ini file.
