### PR TITLE
Remove cron from fpm images and add to cli

### DIFF
--- a/5.5/apache/php.ini
+++ b/5.5/apache/php.ini
@@ -7,7 +7,3 @@ memory_limit=512M
 ; Sendmail
 sendmail_path=/usr/sbin/sendmail -t -i
 
-; Xdebug settings
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-

--- a/5.5/cli/Dockerfile
+++ b/5.5/cli/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
 RUN apt-get update \
-    && apt-get install -y cron \
+    && apt-get install -y cron rsyslog \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/5.5/cli/Dockerfile
+++ b/5.5/cli/Dockerfile
@@ -19,6 +19,10 @@ RUN apt-get update \
 
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
+RUN apt-get update \
+    && apt-get install -y cron \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 

--- a/5.5/cli/Dockerfile.m4
+++ b/5.5/cli/Dockerfile.m4
@@ -5,6 +5,7 @@ MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
 include(`dockerfile/extensions.m4')
 include(`dockerfile/memcached.m4')
 include(`dockerfile/xdebug.m4')
+include(`dockerfile/cron.m4')
 include(`dockerfile/php-ini.m4')
 
 include(`dockerfile/entrypoint.m4')

--- a/5.5/cli/entrypoint.sh
+++ b/5.5/cli/entrypoint.sh
@@ -2,6 +2,12 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
+# Setup Magento cron
+if [ "$ENABLE_CRON" = "true" ]; then
+    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
+    /etc/init.d/cron start
+fi
+
 # Start sendmail
 /etc/init.d/sendmail start
 

--- a/5.5/cli/entrypoint.sh
+++ b/5.5/cli/entrypoint.sh
@@ -2,8 +2,15 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
+CRON_LOG=/var/log/cron.log
+
 # Setup Magento cron
 echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start
 
 # Start sendmail
 /etc/init.d/sendmail start

--- a/5.5/cli/entrypoint.sh
+++ b/5.5/cli/entrypoint.sh
@@ -3,10 +3,7 @@
 [ "$DEBUG" = "true" ] && set -x
 
 # Setup Magento cron
-if [ "$ENABLE_CRON" = "true" ]; then
-    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
-    /etc/init.d/cron start
-fi
+echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
 
 # Start sendmail
 /etc/init.d/sendmail start

--- a/5.5/cli/entrypoint.sh.m4
+++ b/5.5/cli/entrypoint.sh.m4
@@ -1,4 +1,5 @@
 include(`entrypoint-sh/header.m4')
+include(`entrypoint-sh/cron.m4')
 include(`entrypoint-sh/sendmail.m4')
 include(`entrypoint-sh/xdebug.m4')
 include(`entrypoint-sh/passthrough.m4')

--- a/5.5/cli/php.ini
+++ b/5.5/cli/php.ini
@@ -7,7 +7,3 @@ memory_limit=512M
 ; Sendmail
 sendmail_path=/usr/sbin/sendmail -t -i
 
-; Xdebug settings
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -19,10 +19,6 @@ RUN apt-get update \
 
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
-RUN apt-get update \
-    && apt-get install -y cron \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 

--- a/5.5/fpm/Dockerfile.m4
+++ b/5.5/fpm/Dockerfile.m4
@@ -5,7 +5,6 @@ MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
 include(`dockerfile/extensions.m4')
 include(`dockerfile/memcached.m4')
 include(`dockerfile/xdebug.m4')
-include(`dockerfile/cron.m4')
 include(`dockerfile/php-ini.m4')
 
 include(`dockerfile/entrypoint.m4')

--- a/5.5/fpm/entrypoint.sh
+++ b/5.5/fpm/entrypoint.sh
@@ -2,12 +2,6 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-# Setup Magento cron
-if [ "$ENABLE_CRON" = "true" ]; then
-    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
-    /etc/init.d/cron start
-fi
-
 # Start sendmail
 /etc/init.d/sendmail start
 

--- a/5.5/fpm/entrypoint.sh.m4
+++ b/5.5/fpm/entrypoint.sh.m4
@@ -1,5 +1,4 @@
 include(`entrypoint-sh/header.m4')
-include(`entrypoint-sh/cron.m4')
 include(`entrypoint-sh/sendmail.m4')
 include(`entrypoint-sh/xdebug.m4')
 include(`entrypoint-sh/passthrough.m4')

--- a/5.6/apache/php.ini
+++ b/5.6/apache/php.ini
@@ -7,7 +7,3 @@ memory_limit=512M
 ; Sendmail
 sendmail_path=/usr/sbin/sendmail -t -i
 
-; Xdebug settings
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-

--- a/5.6/cli/Dockerfile
+++ b/5.6/cli/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
 RUN apt-get update \
-    && apt-get install -y cron \
+    && apt-get install -y cron rsyslog \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/5.6/cli/Dockerfile
+++ b/5.6/cli/Dockerfile
@@ -19,6 +19,10 @@ RUN apt-get update \
 
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
+RUN apt-get update \
+    && apt-get install -y cron \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 

--- a/5.6/cli/Dockerfile.m4
+++ b/5.6/cli/Dockerfile.m4
@@ -5,6 +5,7 @@ MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
 include(`dockerfile/extensions.m4')
 include(`dockerfile/memcached.m4')
 include(`dockerfile/xdebug.m4')
+include(`dockerfile/cron.m4')
 include(`dockerfile/php-ini.m4')
 
 include(`dockerfile/entrypoint.m4')

--- a/5.6/cli/entrypoint.sh
+++ b/5.6/cli/entrypoint.sh
@@ -2,6 +2,12 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
+# Setup Magento cron
+if [ "$ENABLE_CRON" = "true" ]; then
+    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
+    /etc/init.d/cron start
+fi
+
 # Start sendmail
 /etc/init.d/sendmail start
 

--- a/5.6/cli/entrypoint.sh
+++ b/5.6/cli/entrypoint.sh
@@ -2,8 +2,15 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
+CRON_LOG=/var/log/cron.log
+
 # Setup Magento cron
 echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start
 
 # Start sendmail
 /etc/init.d/sendmail start

--- a/5.6/cli/entrypoint.sh
+++ b/5.6/cli/entrypoint.sh
@@ -3,10 +3,7 @@
 [ "$DEBUG" = "true" ] && set -x
 
 # Setup Magento cron
-if [ "$ENABLE_CRON" = "true" ]; then
-    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
-    /etc/init.d/cron start
-fi
+echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
 
 # Start sendmail
 /etc/init.d/sendmail start

--- a/5.6/cli/entrypoint.sh.m4
+++ b/5.6/cli/entrypoint.sh.m4
@@ -1,4 +1,5 @@
 include(`entrypoint-sh/header.m4')
+include(`entrypoint-sh/cron.m4')
 include(`entrypoint-sh/sendmail.m4')
 include(`entrypoint-sh/xdebug.m4')
 include(`entrypoint-sh/passthrough.m4')

--- a/5.6/cli/php.ini
+++ b/5.6/cli/php.ini
@@ -7,7 +7,3 @@ memory_limit=512M
 ; Sendmail
 sendmail_path=/usr/sbin/sendmail -t -i
 
-; Xdebug settings
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -19,10 +19,6 @@ RUN apt-get update \
 
 RUN yes | pecl install xdebug && docker-php-ext-enable xdebug
 
-RUN apt-get update \
-    && apt-get install -y cron \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 

--- a/5.6/fpm/Dockerfile.m4
+++ b/5.6/fpm/Dockerfile.m4
@@ -5,7 +5,6 @@ MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
 include(`dockerfile/extensions.m4')
 include(`dockerfile/memcached.m4')
 include(`dockerfile/xdebug.m4')
-include(`dockerfile/cron.m4')
 include(`dockerfile/php-ini.m4')
 
 include(`dockerfile/entrypoint.m4')

--- a/5.6/fpm/entrypoint.sh
+++ b/5.6/fpm/entrypoint.sh
@@ -2,12 +2,6 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-# Setup Magento cron
-if [ "$ENABLE_CRON" = "true" ]; then
-    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
-    /etc/init.d/cron start
-fi
-
 # Start sendmail
 /etc/init.d/sendmail start
 

--- a/5.6/fpm/entrypoint.sh.m4
+++ b/5.6/fpm/entrypoint.sh.m4
@@ -1,5 +1,4 @@
 include(`entrypoint-sh/header.m4')
-include(`entrypoint-sh/cron.m4')
 include(`entrypoint-sh/sendmail.m4')
 include(`entrypoint-sh/xdebug.m4')
 include(`entrypoint-sh/passthrough.m4')

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -21,3 +21,9 @@ RUN a2enmod rewrite headers
 
 COPY magento.conf /etc/apache2/conf-enabled/
 
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["apache2-foreground"]
+

--- a/7.0/apache/Dockerfile.m4
+++ b/7.0/apache/Dockerfile.m4
@@ -6,3 +6,6 @@ include(`dockerfile/extensions.m4')
 include(`dockerfile/xdebug-2.4.0RC3.m4')
 include(`dockerfile/php-ini.m4')
 include(`dockerfile/apache.m4')
+
+include(`dockerfile/entrypoint.m4')
+include(`dockerfile/cmd-apache.m4')

--- a/7.0/apache/entrypoint.sh
+++ b/7.0/apache/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+# Start sendmail
+/etc/init.d/sendmail start
+
+# Configure Xdebug
+if [ "$XDEBUG_CONFIG" ]; then
+    echo "" > /usr/local/etc/php/conf.d/zz-xdebug.ini
+    for config in $XDEBUG_CONFIG; do
+        echo "xdebug.$config" >> /usr/local/etc/php/conf.d/zz-xdebug.ini
+    done
+fi
+
+# Execute the supplied command
+exec "$@"
+

--- a/7.0/apache/entrypoint.sh.m4
+++ b/7.0/apache/entrypoint.sh.m4
@@ -1,0 +1,4 @@
+include(`entrypoint-sh/header.m4')
+include(`entrypoint-sh/sendmail.m4')
+include(`entrypoint-sh/xdebug.m4')
+include(`entrypoint-sh/passthrough.m4')

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -16,7 +16,7 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
 RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
 
 RUN apt-get update \
-    && apt-get install -y cron \
+    && apt-get install -y cron rsyslog \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -17,3 +17,7 @@ RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -15,6 +15,10 @@ RUN build_packages="libmcrypt-dev libpng12-dev libfreetype6-dev libjpeg62-turbo-
 
 RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
 
+RUN apt-get update \
+    && apt-get install -y cron \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
 

--- a/7.0/cli/Dockerfile.m4
+++ b/7.0/cli/Dockerfile.m4
@@ -5,3 +5,5 @@ MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
 include(`dockerfile/extensions.m4')
 include(`dockerfile/xdebug-2.4.0RC3.m4')
 include(`dockerfile/php-ini.m4')
+
+include(`dockerfile/entrypoint.m4')

--- a/7.0/cli/Dockerfile.m4
+++ b/7.0/cli/Dockerfile.m4
@@ -4,6 +4,7 @@ MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
 
 include(`dockerfile/extensions.m4')
 include(`dockerfile/xdebug-2.4.0RC3.m4')
+include(`dockerfile/cron.m4')
 include(`dockerfile/php-ini.m4')
 
 include(`dockerfile/entrypoint.m4')

--- a/7.0/cli/entrypoint.sh
+++ b/7.0/cli/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+# Setup Magento cron
+if [ "$ENABLE_CRON" = "true" ]; then
+    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
+    /etc/init.d/cron start
+fi
+
+# Start sendmail
+/etc/init.d/sendmail start
+
+# Configure Xdebug
+if [ "$XDEBUG_CONFIG" ]; then
+    echo "" > /usr/local/etc/php/conf.d/zz-xdebug.ini
+    for config in $XDEBUG_CONFIG; do
+        echo "xdebug.$config" >> /usr/local/etc/php/conf.d/zz-xdebug.ini
+    done
+fi
+
+# Execute the supplied command
+exec "$@"
+

--- a/7.0/cli/entrypoint.sh
+++ b/7.0/cli/entrypoint.sh
@@ -2,8 +2,15 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
+CRON_LOG=/var/log/cron.log
+
 # Setup Magento cron
 echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start
 
 # Start sendmail
 /etc/init.d/sendmail start

--- a/7.0/cli/entrypoint.sh
+++ b/7.0/cli/entrypoint.sh
@@ -3,10 +3,7 @@
 [ "$DEBUG" = "true" ] && set -x
 
 # Setup Magento cron
-if [ "$ENABLE_CRON" = "true" ]; then
-    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
-    /etc/init.d/cron start
-fi
+echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
 
 # Start sendmail
 /etc/init.d/sendmail start

--- a/7.0/cli/entrypoint.sh.m4
+++ b/7.0/cli/entrypoint.sh.m4
@@ -1,0 +1,5 @@
+include(`entrypoint-sh/header.m4')
+include(`entrypoint-sh/cron.m4')
+include(`entrypoint-sh/sendmail.m4')
+include(`entrypoint-sh/xdebug.m4')
+include(`entrypoint-sh/passthrough.m4')

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -17,3 +17,9 @@ RUN yes | pecl install xdebug-2.4.0RC3 && docker-php-ext-enable xdebug
 
 COPY php.ini /usr/local/etc/php/conf.d/zz-magento.ini
 
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["php-fpm"]
+

--- a/7.0/fpm/Dockerfile.m4
+++ b/7.0/fpm/Dockerfile.m4
@@ -5,3 +5,6 @@ MAINTAINER Tomas Gerulaitis <tomas.gerulaitis@meanbee.com>
 include(`dockerfile/extensions.m4')
 include(`dockerfile/xdebug-2.4.0RC3.m4')
 include(`dockerfile/php-ini.m4')
+
+include(`dockerfile/entrypoint.m4')
+include(`dockerfile/cmd-fpm.m4')

--- a/7.0/fpm/entrypoint.sh
+++ b/7.0/fpm/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+[ "$DEBUG" = "true" ] && set -x
+
+# Start sendmail
+/etc/init.d/sendmail start
+
+# Configure Xdebug
+if [ "$XDEBUG_CONFIG" ]; then
+    echo "" > /usr/local/etc/php/conf.d/zz-xdebug.ini
+    for config in $XDEBUG_CONFIG; do
+        echo "xdebug.$config" >> /usr/local/etc/php/conf.d/zz-xdebug.ini
+    done
+fi
+
+# Execute the supplied command
+exec "$@"
+

--- a/7.0/fpm/entrypoint.sh.m4
+++ b/7.0/fpm/entrypoint.sh.m4
@@ -1,0 +1,4 @@
+include(`entrypoint-sh/header.m4')
+include(`entrypoint-sh/sendmail.m4')
+include(`entrypoint-sh/xdebug.m4')
+include(`entrypoint-sh/passthrough.m4')

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A sample `docker-compose.yml` configuration:
 
     cron:
       image: meanbee/magento:5.6-cli
-      command: cron -f
+      command: bash -c "cron && tail -f /var/log/cron.log"
 
 # Options
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ A sample `docker-compose.yml` configuration:
       ports:
         - 3306
 
+    cron:
+      image: meanbee/magento:5.6-cli
+      command: cron -f
+
 # Options
 
 ## Xdebug

--- a/lib/dockerfile/cron.m4
+++ b/lib/dockerfile/cron.m4
@@ -1,3 +1,3 @@
 RUN apt-get update \
-    && apt-get install -y cron \
+    && apt-get install -y cron rsyslog \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/lib/entrypoint-sh/cron.m4
+++ b/lib/entrypoint-sh/cron.m4
@@ -1,2 +1,9 @@
+CRON_LOG=/var/log/cron.log
+
 # Setup Magento cron
 echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
+
+# Get rsyslog running for cron output
+touch $CRON_LOG
+echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+service rsyslog start

--- a/lib/entrypoint-sh/cron.m4
+++ b/lib/entrypoint-sh/cron.m4
@@ -1,5 +1,2 @@
 # Setup Magento cron
-if [ "$ENABLE_CRON" = "true" ]; then
-    echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento
-    /etc/init.d/cron start
-fi
+echo "* * * * * root su www-data -s /bin/bash -c 'sh $MAGE_ROOT_DIR/cron.sh'" > /etc/cron.d/magento

--- a/makefile
+++ b/makefile
@@ -27,11 +27,11 @@ all: */*/Dockerfile
 5.6/apache/Dockerfile: 5.6/apache/Dockerfile.m4 5.6/apache/php.ini 5.6/apache/magento.conf 5.6/apache/entrypoint.sh $(TEMPLATE_LIB)
 	m4 -I ./lib $@.m4 > $@
 
-7.0/cli/Dockerfile: 7.0/cli/Dockerfile.m4 7.0/cli/php.ini $(TEMPLATE_LIB)
+7.0/cli/Dockerfile: 7.0/cli/Dockerfile.m4 7.0/cli/php.ini 7.0/cli/entrypoint.sh $(TEMPLATE_LIB)
 	m4 -I ./lib $@.m4 > $@
 
-7.0/apache/Dockerfile: 7.0/apache/Dockerfile.m4 7.0/apache/php.ini 7.0/apache/magento.conf $(TEMPLATE_LIB)
+7.0/apache/Dockerfile: 7.0/apache/Dockerfile.m4 7.0/apache/php.ini 7.0/apache/magento.conf 7.0/apache/entrypoint.sh $(TEMPLATE_LIB)
 	m4 -I ./lib $@.m4 > $@
 
-7.0/fpm/Dockerfile: 7.0/fpm/Dockerfile.m4 7.0/fpm/php.ini $(TEMPLATE_LIB)
+7.0/fpm/Dockerfile: 7.0/fpm/Dockerfile.m4 7.0/fpm/php.ini 7.0/fpm/entrypoint.sh $(TEMPLATE_LIB)
 	m4 -I ./lib $@.m4 > $@


### PR DESCRIPTION
- Cron doesn't provide a nice way of seeing what its up to, so had to install rsyslog and then tail its log file to see what's going on
- Added entrypoint definitions to the PHP 7 images to support cron (needed it on CLI, but added it on fpm and apache too)

Closes #23.
