### PR TITLE
Retry tool downloads multiple times incase of error

### DIFF
--- a/5.5/cli/Dockerfile
+++ b/5.5/cli/Dockerfile
@@ -36,11 +36,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/5.5/cli/Dockerfile
+++ b/5.5/cli/Dockerfile
@@ -36,11 +36,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/5.6/cli/Dockerfile
+++ b/5.6/cli/Dockerfile
@@ -36,11 +36,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/5.6/cli/Dockerfile
+++ b/5.6/cli/Dockerfile
@@ -36,11 +36,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -36,11 +36,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -36,11 +36,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/7.1/cli/Dockerfile
+++ b/7.1/cli/Dockerfile
@@ -30,11 +30,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/7.1/cli/Dockerfile
+++ b/7.1/cli/Dockerfile
@@ -30,11 +30,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/src/Dockerfile-cli
+++ b/src/Dockerfile-cli
@@ -4,11 +4,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/

--- a/src/Dockerfile-cli
+++ b/src/Dockerfile-cli
@@ -4,11 +4,11 @@ ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
     && pip install awscli \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
-    && curl -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
-    && curl -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
-    && curl -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
-    && curl -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
+    && curl --retry 10 --retry-delay 3 -sS https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
+    && curl --retry 10 --retry-delay 3 -sS -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
+    && curl --retry 10 --retry-delay 3 -sS https://s3-eu-west-1.amazonaws.com/magedbm-releases/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://files.magerun.net/n98-magerun.phar -o $BIN_DIR/n98-magerun.phar && chmod +x $BIN_DIR/n98-magerun.phar \
+    && curl --retry 10 --retry-delay 3 -sS https://raw.githubusercontent.com/colinmollenhour/modman/master/modman -o $BIN_DIR/modman && chmod +x $BIN_DIR/modman \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY bin/* $BIN_DIR/


### PR DESCRIPTION
There have been a couple of times where the build has stalled or errored due to an SSL error for some reason at this stage during the image build.

I've modified the curl call to try again if a transient error is encountered.

I'm not actually 100% if the SSL error that was encountered counts as a transient error for this, but this was the closet flag I could find on the command to try and deal with it.