### PR TITLE
Cronjob fix for magento 2.1 on php7.0 + memory limit

### DIFF
--- a/7.0/apache/php.ini
+++ b/7.0/apache/php.ini
@@ -2,7 +2,7 @@
 date.timezone=UTC
 
 ; Magento recommended settings
-memory_limit=512M
+memory_limit=756M
 max_execution_time = 600
 
 ; Request size limits

--- a/7.0/cli/entrypoint.sh
+++ b/7.0/cli/entrypoint.sh
@@ -5,7 +5,8 @@
 CRON_LOG=/var/log/cron.log
 
 # Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
+# See: http://devdocs.magento.com/guides/v2.1/config-guide/cli/config-cli-subcommands-cron.html
+echo "* * * * * root su www-data -s /bin/bash -c '$(pwd)/bin/magento cron:run | grep -v \"Ran jobs by schedule\"'" > /etc/cron.d/magento
 
 # Get rsyslog running for cron output
 touch $CRON_LOG

--- a/7.0/cli/php.ini
+++ b/7.0/cli/php.ini
@@ -2,7 +2,7 @@
 date.timezone=UTC
 
 ; Magento recommended settings
-memory_limit=512M
+memory_limit=756M
 max_execution_time = 600
 
 ; Request size limits

--- a/7.0/fpm/php.ini
+++ b/7.0/fpm/php.ini
@@ -2,7 +2,7 @@
 date.timezone=UTC
 
 ; Magento recommended settings
-memory_limit=512M
+memory_limit=756M
 max_execution_time = 600
 
 ; Request size limits

--- a/7.1/apache/php.ini
+++ b/7.1/apache/php.ini
@@ -2,7 +2,7 @@
 date.timezone=UTC
 
 ; Magento recommended settings
-memory_limit=512M
+memory_limit=756M
 max_execution_time = 600
 
 ; Request size limits


### PR DESCRIPTION
I think, I just found an error in the crontab definition for magento 2.1 running on php 7.0 images.
Regarding the [documentation](http://devdocs.magento.com/guides/v2.1/config-guide/cli/config-cli-subcommands-cron.html) for 2.1 there is no `cron.sh` anymore (and even so in the [magento2.1 repo branch](https://github.com/magento/magento2/tree/2.1)).
By the way I increased the php memory limit because there was a check during the `bin/magento setup:cron:run` command. This maybe does not apply to all installation methods. For running from source (git clone) it does not apply because we do not need to run it (see the doc above; Example 2 at the end). The recommended memory limit is set to [1gb in production](http://devdocs.magento.com/guides/v2.1/cloud/before/before-workspace-magento-prereqs.html) and we should be fine with the 756mb limit.