### PR TITLE
Fix error 'cannot open kernel log (/proc/kmsg): Operation not permitt…

### DIFF
--- a/5.5/cli/Dockerfile
+++ b/5.5/cli/Dockerfile
@@ -38,6 +38,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \

--- a/5.6/cli/Dockerfile
+++ b/5.6/cli/Dockerfile
@@ -38,6 +38,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -38,6 +38,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \

--- a/7.1/cli/Dockerfile
+++ b/7.1/cli/Dockerfile
@@ -38,6 +38,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \

--- a/7.2/cli/Dockerfile
+++ b/7.2/cli/Dockerfile
@@ -37,6 +37,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \

--- a/7.3/cli/Dockerfile
+++ b/7.3/cli/Dockerfile
@@ -37,6 +37,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \

--- a/7.4/cli/Dockerfile
+++ b/7.4/cli/Dockerfile
@@ -31,6 +31,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \

--- a/src/Dockerfile-cli
+++ b/src/Dockerfile-cli
@@ -3,6 +3,7 @@
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
     && apt-get install -y cron git groff <?php echo $mysql_client_package ?> python-pip rsyslog sudo \
+    && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
     && pip install awscli \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \


### PR DESCRIPTION
This fixes the error:

> cannot open kernel log (/proc/kmsg): Operation not permitted.

by disabling logging of kernel logs which are really not necessary inside a container.