### PR TITLE
Fix build error and add ENABLE_CRON flag

### DIFF
--- a/5.5/cli/Dockerfile
+++ b/5.5/cli/Dockerfile
@@ -37,9 +37,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
+    && apt-get install -y cron git groff mysql-client rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/5.5/cli/entrypoint.sh
+++ b/5.5/cli/entrypoint.sh
@@ -2,15 +2,13 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/5.6/cli/Dockerfile
+++ b/5.6/cli/Dockerfile
@@ -37,9 +37,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
+    && apt-get install -y cron git groff mysql-client rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/5.6/cli/entrypoint.sh
+++ b/5.6/cli/entrypoint.sh
@@ -2,15 +2,13 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.0/cli/Dockerfile
+++ b/7.0/cli/Dockerfile
@@ -37,9 +37,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff mysql-client python-pip rsyslog sudo \
+    && apt-get install -y cron git groff mysql-client rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/7.0/cli/entrypoint.sh
+++ b/7.0/cli/entrypoint.sh
@@ -2,15 +2,13 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.1/cli/Dockerfile
+++ b/7.1/cli/Dockerfile
@@ -37,9 +37,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && apt-get install -y cron git groff default-mysql-client rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/7.1/cli/entrypoint.sh
+++ b/7.1/cli/entrypoint.sh
@@ -2,15 +2,13 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.2/cli/Dockerfile
+++ b/7.2/cli/Dockerfile
@@ -36,9 +36,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && apt-get install -y cron git groff default-mysql-client rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/7.2/cli/entrypoint.sh
+++ b/7.2/cli/entrypoint.sh
@@ -2,15 +2,13 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.3/cli/Dockerfile
+++ b/7.3/cli/Dockerfile
@@ -36,9 +36,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && apt-get install -y cron git groff default-mysql-client rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/7.3/cli/entrypoint.sh
+++ b/7.3/cli/entrypoint.sh
@@ -2,15 +2,13 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/7.4/cli/Dockerfile
+++ b/7.4/cli/Dockerfile
@@ -30,9 +30,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff default-mysql-client python-pip rsyslog sudo \
+    && apt-get install -y cron git groff default-mysql-client rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/7.4/cli/entrypoint.sh
+++ b/7.4/cli/entrypoint.sh
@@ -2,15 +2,13 @@
 
 [ "$DEBUG" = "true" ] && set -x
 
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 
 # Configure Sendmail if required
 if [ "$ENABLE_SENDMAIL" == "true" ]; then

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ See [docker-compose.yml](docker-compose.yml) for a sample configuration.
 
 # Options
 
+## Cron
+
+The `cli` image supports running Magento's cron task automatically. This is disabled by default but can be enabled with
+the following environment variable:
+
+    ENABLE_CRON=true
+
+*Note:* The cron container must be run as `root` (this is the default) and the cron task will automatically be run as the `www-data` user.
+
 ## Sendmail
 
 All images have sendmail installed for emails, however it is not enabled by default. To enable sendmail, use the following environment variable:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - appdata
     environment:
       - ENABLE_SENDMAIL=true
+      - ENABLE_CRON=true
     links:
       - db
 

--- a/src/Dockerfile-cli
+++ b/src/Dockerfile-cli
@@ -2,9 +2,10 @@
 
 ENV BIN_DIR "/usr/local/bin"
 RUN apt-get update \
-    && apt-get install -y cron git groff <?php echo $mysql_client_package ?> python-pip rsyslog sudo \
+    && apt-get install -y cron git groff <?php echo $mysql_client_package ?> rsyslog sudo unzip \
+    && echo "* * * * * /var/www/html/cron.sh" | sudo -u www-data crontab - \
     && sed -i '/imklog/s/^/#/' /etc/rsyslog.conf \
-    && pip install awscli \
+    && curl --retry 10 --retry-delay 3 https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install && rm -rf ./aws \
     && curl --retry 10 --retry-delay 3 https://getcomposer.org/installer | php -- --install-dir=$BIN_DIR --filename=composer \
     && curl --retry 10 --retry-delay 3 -L https://github.com/punkstar/mageconfigsync/releases/download/0.4.0/mageconfigsync-0.4.0.phar -o $BIN_DIR/mageconfigsync && chmod +x $BIN_DIR/mageconfigsync \
     && curl --retry 10 --retry-delay 3 -L https://github.com/meanbee/magedbm/releases/download/v1.6.0/magedbm.phar -o $BIN_DIR/magedbm.phar && chmod +x $BIN_DIR/magedbm.phar \

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -3,15 +3,13 @@
 [ "$DEBUG" = "true" ] && set -x
 
 <?php if (!empty($include_cron)): ?>
-CRON_LOG=/var/log/cron.log
-
-# Setup Magento cron
-echo "* * * * * root su www-data -s /bin/bash -c 'sh $(pwd)/cron.sh'" > /etc/cron.d/magento
-
-# Get rsyslog running for cron output
-touch $CRON_LOG
-echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
-service rsyslog start
+if [ "$ENABLE_CRON" == "true" ]; then
+  # Get rsyslog running for cron output
+  CRON_LOG=/var/log/cron.log
+  touch $CRON_LOG
+  echo "cron.* $CRON_LOG" > /etc/rsyslog.d/cron.conf
+  service rsyslog start
+fi
 <?php endif; ?>
 
 # Configure Sendmail if required


### PR DESCRIPTION
This fixes a build error for installing awscli using the latest officially recommended method.

It also fixes an issue with running the cli image as a non-root user for one-off jobs that don't need cron. So now to enable cron the `ENABLE_CRON` env var must be set to `true` and this is set by default for the `cron` service in `docker-compose.yaml`.